### PR TITLE
create in-memory clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.idea

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ deps: # @HELP install dependencies
 	go get -t -d -v ./...
 
 build: # @HELP build the packages
-	sh $(PWD)/scripts/build.sh
+	$(PWD)/scripts/build.sh
 
 ci: # @HELP executes on CI
 ci: deps test dep-linter lint

--- a/internal/memory_clock.go
+++ b/internal/memory_clock.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"github.com/jabolina/d-clock/pkg/d_clock"
+	"sync/atomic"
+)
+
+// A very simple in-memory Clock implementation.
+// This version is not distributed but is cheaper and can be used
+// by a single process.
+type InMemoryClock struct {
+	// The actual clock value.
+	time uint64
+}
+
+// Implements the Clock interface.
+func (i *InMemoryClock) Tick() (uint64, error) {
+	return atomic.AddUint64(&i.time, 1), nil
+}
+
+// Implements the Clock interface.
+func (i *InMemoryClock) Tack() (uint64, error) {
+	return atomic.LoadUint64(&i.time), nil
+}
+
+// Implements the Clock interface.
+func (i *InMemoryClock) Leap(to uint64) (uint64, error) {
+	atomic.StoreUint64(&i.time, to)
+	return to, nil
+}
+
+// Creates a new InMemoryClock.
+func NewInMemoryClock() d_clock.Clock {
+	return &InMemoryClock{}
+}

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -1,1 +1,0 @@
-package pkg

--- a/pkg/d_clock/api.go
+++ b/pkg/d_clock/api.go
@@ -1,0 +1,1 @@
+package d_clock

--- a/pkg/d_clock/clock.go
+++ b/pkg/d_clock/clock.go
@@ -1,0 +1,14 @@
+package d_clock
+
+// The generic interface a Clock must have. Using
+// this interface will have basic functionalities.
+type Clock interface {
+	// The clock increases by 1.
+	Tick() (uint64, error)
+
+	// Returns the current clock value.
+	Tack() (uint64, error)
+
+	// Leap the clock to the given time.
+	Leap(uint64) (uint64, error)
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/env bash
 
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}

--- a/test/in_memory_clock_test.go
+++ b/test/in_memory_clock_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"github.com/jabolina/d-clock/internal"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Test_InMemoryClock(t *testing.T) {
+	clk := internal.NewInMemoryClock()
+	group := sync.WaitGroup{}
+	apply := func() {
+		defer group.Done()
+		_, err := clk.Tick()
+		if err != nil {
+			t.Errorf("error ticking clock: %#v", err)
+		}
+	}
+
+	group.Add(ConcurrencyLevel)
+	for i := 0; i < ConcurrencyLevel; i++ {
+		go apply()
+	}
+
+	if !WaitOrTimeout(group.Wait, time.Second) {
+		t.Errorf("failed waiting ticks")
+	}
+
+	current, err := clk.Tack()
+	if err != nil {
+		t.Errorf("error reading value: %#v", err)
+	}
+
+	if current != uint64(ConcurrencyLevel) {
+		t.Errorf("expected %d, found %d", ConcurrencyLevel, current)
+	}
+}

--- a/test/testing.go
+++ b/test/testing.go
@@ -1,0 +1,19 @@
+package test
+
+import "time"
+
+var ConcurrencyLevel = 5000
+
+func WaitOrTimeout(cb func(), duration time.Duration) bool {
+	done := make(chan bool)
+	go func() {
+		cb()
+		done <- true
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(duration):
+		return false
+	}
+}


### PR DESCRIPTION
A simple in-memory alternative that is thread safe and can be used by a single host.
